### PR TITLE
Change Collapse Weights's mix set to Add

### DIFF
--- a/operators/modtools.py
+++ b/operators/modtools.py
@@ -839,7 +839,7 @@ class collapseWeights(modTool):
                     m.vertex_group_a = base
                     m.vertex_group_b = group
                     m.mix_mode = "ADD"
-                    m.mix_set = "OR"
+                    m.mix_set = "ALL"
                     bpy.ops.object.modifier_apply(modifier = m.name)
                     deleteTag.append(mesh.vertex_groups[group])
                 mesh.vertex_groups[base].name = name


### PR DESCRIPTION
In some mods, Collapse Weight does not work properly.
For example, with a HNM, some body parts collapses.
So let me change the mix set of Collapse Weights to Add.

Thanks for great mod-tools!!